### PR TITLE
fix: testジョブをtest_modules空の場合にスキップするよう修正

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -47,6 +47,7 @@ jobs:
     name: Test (${{ matrix.module }})
     runs-on: ubuntu-latest
     needs: find-modules
+    if: ${{ needs.find-modules.outputs.test-modules != '[]' }}
     strategy:
       matrix:
         module: ${{ fromJson(needs.find-modules.outputs.test-modules) }}


### PR DESCRIPTION
- test_modules配列が空の場合、testジョブ全体をスキップ
- テンプレートリポジトリでテストファイルがない場合のマトリックスエラーを解消
- GitHub App permissionの問題を修正

🤖 Generated with [Claude Code](https://claude.ai/code)