### PR TITLE
fix: yamllint警告・エラーを全て解消

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for more information:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,4 @@
+---
 name: Claude Code Review
 
 on:
@@ -17,14 +18,12 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +38,6 @@ jobs:
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:
@@ -48,12 +46,10 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
-          
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:
@@ -61,18 +57,14 @@ jobs:
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,4 @@
+---
 name: Claude Code
 
 on:
@@ -23,7 +24,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read  # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -99,8 +99,8 @@ jobs:
           version: latest
           args: --config=${{ github.workspace }}/.golangci.yml
           working-directory: ${{ matrix.module }}
-        # 緊急で修正する必要があり、lint, test等を完全に通す余力がない場合は以下のコメントアウトを解除
-        # continue-on-error: true
+          # 緊急で修正する必要があり、lint, test等を完全に通す余力がない場合は以下のコメントアウトを解除
+          # continue-on-error: true
 
   yaml-lint:
     name: YAML Lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+---
 version: "2"
 
 run:
@@ -5,22 +6,22 @@ run:
 
 linters:
   enable:
-    # エラーチェック系
-    - errcheck # エラーチェックの漏れを検出
-    - errorlint # エラー処理のベストプラクティス
-    - govet # コンパイルエラーや疑わしいコードを検出
-    - staticcheck # 高度な静的解析
+    #  エラーチェック系
+    - errcheck  # エラーチェックの漏れを検出
+    - errorlint  # エラー処理のベストプラクティス
+    - govet  # コンパイルエラーや疑わしいコードを検出
+    - staticcheck  # 高度な静的解析
 
-    # コード品質系
-    - gocritic # コードの改善提案
-    - gosec # セキュリティチェック
-    - ineffassign # 無効な代入の検出
-    - noctx # contextの使用漏れ
-    - rowserrcheck # データベース操作のエラーチェック
-    - sqlclosecheck # SQLのクローズ漏れ
+    #  コード品質系
+    - gocritic  # コードの改善提案
+    - gosec  # セキュリティチェック
+    - ineffassign  # 無効な代入の検出
+    - noctx  # contextの使用漏れ
+    - rowserrcheck  # データベース操作のエラーチェック
+    - sqlclosecheck  # SQLのクローズ漏れ
 
-    # パフォーマンス系
-    - perfsprint # 文字列連結の最適化
+    #  パフォーマンス系
+    - perfsprint  # 文字列連結の最適化
   settings:
     govet:
       enable-all: true
@@ -28,7 +29,7 @@ linters:
         - fieldalignment
   exclusions:
     rules:
-      # test fileで一部のlinterを無効化
+      #  test fileで一部のlinterを無効化
       - path: _test\.go
         linters:
           - errcheck

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,4 @@
+---
 pre-commit:
   commands:
     dprint-fmt:
@@ -14,7 +15,7 @@ pre-commit:
         files=$(echo "{staged_files}" | grep -E '\.(yml|yaml)$' || true)
         if [ -n "$files" ]; then
           echo "$files" # lint対象のファイル名出力
-          echo "$files" | xargs -I {} yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}" {}
+          echo "$files" | tr ' ' '\n' | xargs -I {} yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}" {}
         fi
 
 pre-push:


### PR DESCRIPTION
- 全YAMLファイルにドキュメント開始 '---' を追加
- trailing spacesとempty-linesエラーを修正
- コメント前のスペース不足を統一（2スペースに修正）
- コメントインデントを適切なレベルに調整
- lefthookのyamllintコマンドでファイル名分割処理を修正
- yamllint実行で警告・エラーが0件になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)