### PR TITLE
CI修正

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -26,7 +26,6 @@
     "multierr",
     "nolint",
     "pkglogger",
-    "reviewdog",
     "shellcheck",
     "testutil",
     "timonwong",

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,4 +17,3 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/ins
 # /go/pkg/mod/cache/download/ 配下のownerがrootになることを防ぐためvscode user使用
 USER vscode
 RUN go install mvdan.cc/gofumpt@latest
-RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,3 +17,4 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/ins
 # /go/pkg/mod/cache/download/ 配下のownerがrootになることを防ぐためvscode user使用
 USER vscode
 RUN go install mvdan.cc/gofumpt@latest
+RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/services/api"
+    schedule:
+      interval: monthly
+  - package-ecosystem: "gomod"
+    directory: "/services/batch"
+    schedule:
+      interval: monthly
+  - package-ecosystem: "gomod"
+    directory: "/pkg/logger"
     schedule:
       interval: monthly

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -108,6 +108,11 @@ jobs:
   yaml-lint:
     name: YAML Lint
     runs-on: ubuntu-latest
+    # actionlintがPRに対してコメントをするためにpermission付与
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -24,7 +24,7 @@ jobs:
           # -xオプションを指定しないとshell実行ログが出力されないため指定
           set -x
           # Find all modules
-          all_modules=$(find ./services ./pkg -name "go.mod" | xargs dirname | sed 's|^\./||' | sort)
+          all_modules=$(find ./services ./pkg -name "go.mod" -print0 | xargs -0 dirname | sed 's|^\./||' | sort)
 
           # Find modules with test files
           test_modules=""
@@ -121,4 +121,4 @@ jobs:
       - name: Run yamllint
         run: |
           # Find and lint existing YAML files
-          find . -name "*.yml" -o -name "*.yaml" | xargs -r yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}"
+          find . \( -name '*.yml' -o -name '*.yaml' \) -print0 | xargs -0 -r yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}"

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -108,11 +108,6 @@ jobs:
   yaml-lint:
     name: YAML Lint
     runs-on: ubuntu-latest
-    # actionlintがPRに対してコメントをするためにpermission付与
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -127,11 +122,3 @@ jobs:
         run: |
           # Find and lint existing YAML files
           find . -name "*.yml" -o -name "*.yaml" | xargs -r yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}"
-
-      - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
-        # reviewdogはPR作成時にしか機能しないためif文追加
-        if: github.event_name == 'pull_request'
-        with:
-          fail_level: warning
-          reporter: github-pr-review

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -28,7 +28,7 @@ jobs:
 
           # Find modules with test files
           test_modules=""
-          for module in $all_modules; do
+          for module in "$all_modules"; do
             if test -n "$(find "$module" -name "*_test.go" -print -quit)"; then
               test_modules="$test_modules$module\n"
             fi

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -99,6 +99,9 @@ jobs:
           version: latest
           args: --config=${{ github.workspace }}/.golangci.yml
           working-directory: ${{ matrix.module }}
+          # デフォルトではcacheは`~/.cache/golangci-lint`に保存される。
+          # モノレポ構成ではrestoreに失敗するためcache無効化
+          skip-cache: true
           # 緊急で修正する必要があり、lint, test等を完全に通す余力がない場合は以下のコメントアウトを解除
           # continue-on-error: true
 

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
+        # reviewdogはPR作成時にしか機能しないためif文追加
+        if: github.event_name == 'pull_request'
         with:
           fail_level: warning
           reporter: github-pr-review

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     dprint-fmt:
       run: |
-        files=$(echo "{staged_files}" | grep -E '(Dockerfile$|\.json$|\.md$)' || true)
+        files=$(echo "{staged_files}" | grep -E '(Dockerfile|\.json|\.md)$' || true)
         if [ -n "$files" ]; then
           echo "$files" # フォーマット対象のファイル名出力(go fmt等では出力されるが、dprintでは出力されないため)
           echo "$files" | xargs -r dprint fmt

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     dprint-fmt:
       run: |
-        files=$(echo "{staged_files}" | grep -E '(Dockerfile|\.json|\.md)$' || true)
+        files=$(echo "{staged_files}" | tr ' ' '\n' | grep -E '(Dockerfile|\.json|\.md)$' || true)
         if [ -n "$files" ]; then
           echo "$files" # フォーマット対象のファイル名出力(go fmt等では出力されるが、dprintでは出力されないため)
           echo "$files" | xargs -r dprint fmt

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,10 +12,10 @@ pre-commit:
 
     yaml-lint:
       run: |
-        files=$(echo "{staged_files}" | grep -E '\.(yml|yaml)$' || true)
+        files=$(echo "{staged_files}" | tr ' ' '\n' | grep -E '\.(yml|yaml)$' || true)
         if [ -n "$files" ]; then
           echo "$files" # lint対象のファイル名出力
-          echo "$files" | tr ' ' '\n' | xargs -I {} yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}" {}
+          echo "$files" | xargs -I {} yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}" {}
         fi
 
 pre-push:


### PR DESCRIPTION
# 概要

- dependabotが常時エラーになっていたためgo.modのパスを明示的に指定
- CI実行時のannotation warn対応ノアtめgolangci-lint cache無効化